### PR TITLE
Bump gitlab-branch-source plugin to 1.5.3

### DIFF
--- a/formula.yaml
+++ b/formula.yaml
@@ -233,7 +233,7 @@ plugins:
   - groupId: io.jenkins.plugins
     artifactId: gitlab-branch-source
     source:
-      version: 1.5.1
+      version: 1.5.3
   - groupId: org.jenkins-ci.plugins
     artifactId: htmlpublisher
     source:


### PR DESCRIPTION
The major changes are:
* Fixed an exception when scanning a PR in which the target branch is deleted
* [Feature] Add a private Gitlab server
* [Feature] Add an API for getting Gitlab server and project list