### PR TITLE
Bump gitlab-branch-source plugin from 1.5.3 to 1.5.4

### DIFF
--- a/formula.yaml
+++ b/formula.yaml
@@ -233,7 +233,7 @@ plugins:
   - groupId: io.jenkins.plugins
     artifactId: gitlab-branch-source
     source:
-      version: 1.5.3
+      version: 1.5.4
   - groupId: org.jenkins-ci.plugins
     artifactId: htmlpublisher
     source:


### PR DESCRIPTION
fix https://github.com/kubesphere/kubesphere/issues/3347

See also https://github.com/jenkinsci/gitlab-branch-source-plugin/releases/tag/gitlab-branch-source-1.5.4
