### PR TITLE
Bump configuration-as-code to 1.53

### DIFF
--- a/formula.yaml
+++ b/formula.yaml
@@ -17,35 +17,35 @@ plugins:
   - groupId: io.jenkins
     artifactId: configuration-as-code
     source:
-      version: "1.47"
+      version: "1.53"
   - groupId: io.jenkins.blueocean
     artifactId: blueocean
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: io.jenkins.blueocean
     artifactId: blueocean-bitbucket-pipeline
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: io.jenkins.blueocean
     artifactId: blueocean-commons
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: io.jenkins.blueocean
     artifactId: blueocean-config
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: io.jenkins.blueocean
     artifactId: blueocean-dashboard
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: io.jenkins.blueocean
     artifactId: blueocean-pipeline-api-impl
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: io.jenkins.blueocean
     artifactId: blueocean-pipeline-editor
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: org.jenkins-ci.plugins
     artifactId: async-http-client
     source:
@@ -53,7 +53,7 @@ plugins:
   - groupId: io.jenkins.blueocean
     artifactId: blueocean-core-js
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: org.jenkins-ci.plugins
     artifactId: authentication-tokens
     source:
@@ -61,7 +61,7 @@ plugins:
   - groupId: io.jenkins.blueocean
     artifactId: blueocean-events
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: org.jenkins-ci.plugins
     artifactId: azure-commons
     source:
@@ -69,19 +69,19 @@ plugins:
   - groupId: io.jenkins.blueocean
     artifactId: blueocean-executor-info
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: io.jenkins.blueocean
     artifactId: blueocean-git-pipeline
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: io.jenkins.blueocean
     artifactId: blueocean-jira
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: io.jenkins.blueocean
     artifactId: blueocean-personalization
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: org.jenkins-ci.plugins
     artifactId: antisamy-markup-formatter
     source:
@@ -93,19 +93,19 @@ plugins:
   - groupId: io.jenkins.blueocean
     artifactId: blueocean-github-pipeline
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: io.jenkins.blueocean
     artifactId: blueocean-i18n
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: io.jenkins.blueocean
     artifactId: blueocean-jwt
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: io.jenkins.blueocean
     artifactId: blueocean-rest
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: io.jenkins.plugins
     artifactId: bootstrap4-api
     source:
@@ -133,7 +133,7 @@ plugins:
   - groupId: io.jenkins.blueocean
     artifactId: jenkins-design-language
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: io.jenkins.plugins
     artifactId: localization-support
     source:
@@ -161,15 +161,15 @@ plugins:
   - groupId: io.jenkins.blueocean
     artifactId: blueocean-pipeline-scm-api
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: io.jenkins.blueocean
     artifactId: blueocean-rest-impl
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: io.jenkins.blueocean
     artifactId: blueocean-web
     source:
-      version: 1.24.6-SNAPSHOT
+      version: 1.24.6
   - groupId: org.jenkins-ci.plugins
     artifactId: bouncycastle-api
     source:
@@ -186,10 +186,6 @@ plugins:
     artifactId: font-awesome-api
     source:
       version: 5.15.1-1
-  - groupId: org.jenkins-ci.plugins
-    artifactId: build-monitor-plugin
-    source:
-      version: 1.12-SNAPSHOT
   - groupId: org.jenkins-ci.plugins
     artifactId: build-timeout
     source:
@@ -437,7 +433,7 @@ plugins:
   - groupId: org.jenkins-ci.plugins
     artifactId: pipeline-input-step
     source:
-      version: 2.13-SNAPSHOT
+      version: 2.12
   - groupId: org.jenkins-ci.plugins
     artifactId: pubsub-light
     source:
@@ -489,7 +485,7 @@ plugins:
   - groupId: io.jenkins.plugins
     artifactId: snakeyaml-api
     source:
-      version: 1.27.0
+      version: 1.29.1
   - groupId: org.jenkins-ci.plugins
     artifactId: pipeline-graph-analysis
     source:


### PR DESCRIPTION
* Bump plugin configuration-as-code to [1.53](https://github.com/jenkinsci/configuration-as-code-plugin/releases/tag/configuration-as-code-1.53) because of https://github.com/jenkinsci/configuration-as-code-plugin/pull/1218
* Bump plugin blueocean to [1.24.6](https://github.com/jenkinsci/blueocean-plugin/releases/tag/blueocean-parent-1.24.6) because of https://github.com/jenkinsci/blueocean-plugin/pull/2141
* Don't need [build-monitor-plugin](https://github.com/jan-molak/jenkins-build-monitor-plugin) anymore, and it's never [the official plugin](https://github.com/orgs/jenkinsci/repositories?q=build-monitor&type=&language=&sort=).

fix https://github.com/kubesphere/ks-jenkins/issues/16