### PR TITLE
Remove ruby-runtime

### DIFF
--- a/formula.yaml
+++ b/formula.yaml
@@ -491,10 +491,6 @@ plugins:
     source:
       version: "1.10"
   - groupId: org.jenkins-ci.plugins
-    artifactId: ruby-runtime
-    source:
-      version: "0.12"
-  - groupId: org.jenkins-ci.plugins
     artifactId: run-condition
     source:
       version: "1.3"


### PR DESCRIPTION
See 
![image](https://user-images.githubusercontent.com/1450685/139373830-d6f62ff4-0918-4c4a-acda-dfc424eb64cc.png)
![image](https://user-images.githubusercontent.com/1450685/139373839-d7638c0d-5dd3-4011-9ef5-b1495b7b119b.png)

I have tested it. It works well after removing ruby-runtime

/cc @kubesphere/sig-devops 