### PR TITLE
Bump the Jenkins core version from 2.249.1 to 2.319.1

### DIFF
--- a/formula.yaml
+++ b/formula.yaml
@@ -5,14 +5,14 @@ bundle:
   vendor: Kubesphere Community
 buildSettings:
   docker:
-    base: jenkins/jenkins:2.249.1
+    base: jenkins/jenkins:2.319.1
     tag: kubespheredev/ks-jenkins:{{.version}}
     build: true
 war:
   groupId: org.jenkins-ci.main
   artifactId: jenkins-war
   source:
-    version: 2.249.1
+    version: 2.319.1
 plugins:
   - groupId: io.jenkins
     artifactId: configuration-as-code


### PR DESCRIPTION
Why use Jenkins 2.319.1? There are fewer security issues with this version.