### PR TITLE
Bump kubernetes plugin from 1.27.5 to 1.31.2

### DIFF
--- a/formula.yaml
+++ b/formula.yaml
@@ -204,7 +204,7 @@ plugins:
   - groupId: org.csanchez.jenkins.plugins
     artifactId: kubernetes
     source:
-      version: 1.27.5
+      version: 1.31.2
   - groupId: org.jenkins-ci.plugins
     artifactId: generic-webhook-trigger
     source:


### PR DESCRIPTION
There are some important bug fixes in [v1.31.2](https://github.com/jenkinsci/kubernetes-plugin/releases/tag/kubernetes-1.31.2).