### PR TITLE
Add pipeline-event plugin into formula.yaml

### DIFF
--- a/formula.yaml
+++ b/formula.yaml
@@ -609,6 +609,11 @@ plugins:
     artifactId: cloudbees-disk-usage-simple
     source:
       version: "0.10"
+  - groupId: io.jenkins.plugins
+    artifactId: pipeline-event
+    source:
+      git: https://github.com/JohnNiang/pipeline-event-plugin.git
+      commit: d9d16530433a90d274b3ad8925dfae5d54b22cc9
 systemProperties:
   { hudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID: "true" }
 groovyHooks:


### PR DESCRIPTION
### What this PR dose/ Why we need it

Add [pipeline-event](https://github.com/JohnNiang/pipeline-event-plugin) plugin into ks-jenkins according to https://github.com/jenkinsci/custom-war-packager#configuration-file.

And I have built an temporary docker image for test:

```bash
johnniang/ks-jenkins:pipeline-event
```

After I run the image, I got the expected configuration item:

```bash
docker run --rm -p 8080:8080 johnniang/ks-jenkins:pipeline-event
```

![image](https://user-images.githubusercontent.com/16865714/149660397-167747f9-3e2a-47f7-b04e-2cf8ae420dd3.png)

/kind feature
/cc @kubesphere/sig-devops 