### PR TITLE
Bump base Jenkins to 2.319.3

### DIFF
--- a/formula.yaml
+++ b/formula.yaml
@@ -5,7 +5,7 @@ bundle:
   vendor: Kubesphere Community
 buildSettings:
   docker:
-    base: jenkins/jenkins:2.319.1
+    base: jenkins/jenkins:2.319.2
     tag: {{.tag}}
     output: {{.output}}
     platform: {{.platform}}

--- a/formula.yaml
+++ b/formula.yaml
@@ -5,7 +5,7 @@ bundle:
   vendor: Kubesphere Community
 buildSettings:
   docker:
-    base: jenkins/jenkins:2.319.2
+    base: jenkins/jenkins:2.319.3
     tag: {{.tag}}
     output: {{.output}}
     platform: {{.platform}}


### PR DESCRIPTION
### What this PR dose / Why we need it

Bump base Jenkins to 2.319.3 according to https://www.jenkins.io/changelog-stable/#v2.319.3.

Something should be noticed at https://www.jenkins.io/doc/upgrade-guide/2.319/#upgrading-to-jenkins-lts-2-319-3.

/kind dependency