### PR TITLE
Bump generic event to 0.0.3

### DIFF
--- a/formula.yaml
+++ b/formula.yaml
@@ -612,7 +612,7 @@ plugins:
   - groupId: io.jenkins.plugins
     artifactId: generic-event
     source:
-      version: 0.0.2
+      version: 0.0.3
 systemProperties:
   { hudson.security.csrf.DefaultCrumbIssuer.EXCLUDE_SESSION_ID: "true" }
 groovyHooks:


### PR DESCRIPTION
### What this PR does

Bump generic event to 0.0.3. 

Please see 
- https://github.com/jenkinsci/generic-event-plugin/pull/1
- https://repo.jenkins-ci.org/ui/packages/gav:%2F%2Fio.jenkins.plugins:generic-event/0.0.3?name=generic-event&type=packages&activeTab=builds
![image](https://user-images.githubusercontent.com/16865714/156085878-85c58807-33f4-4e21-bf2c-35c7ecea54a8.png)

/kind chore
/cc @kubesphere/sig-devops 